### PR TITLE
fix URI to not generate broken links in HTML meta

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -4,7 +4,7 @@ images:       /images
 name: Functional Feline Society
 title: Functional Feline Society
 description: Functional Feline Society's adventures in code.
-url: https://functional-feline-society.github.io/blog/
+url: https://functional-feline-society.github.io
 theme: minimal-mistakes-jekyll
 include: ["_pages"]
 highlighter: rouge


### PR DESCRIPTION
As discussed on [Mastodon](https://mastodon.hupel.info/@lars/109767359896431207).